### PR TITLE
Add test utilities, docs, and CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+
+      - name: Go fmt check
+        run: |
+          gofmt -l . | tee /tmp/gofmt.out
+          test ! -s /tmp/gofmt.out
+
+      - name: Go vet
+        run: go vet ./...
+
+      - name: Go test
+        run: go test ./...
+
+      - name: staticcheck
+        run: $(go env GOPATH)/bin/staticcheck ./...

--- a/README.md
+++ b/README.md
@@ -87,3 +87,11 @@ cfg := config.Config{
 ```
 
 When configured, middleware automatically records authentication outcomes, latency, and OpenTelemetry span attributes including issuer, outcome, and error codes.
+
+## Documentation
+
+- [Quick Start](docs/quickstart.md) – integrate the middleware with a `net/http` service.
+- [Extensibility Guide](docs/extensibility.md) – customize token sources, claims validation, and observability hooks.
+- [Testing Helpers](docs/testing.md) – use the in-memory issuer from the `testutil` package to drive unit tests.
+- [Troubleshooting](docs/troubleshooting.md) – resolve common integration issues.
+- [FAQ](docs/faq.md) – answers to frequently asked questions.

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -1,0 +1,55 @@
+# Extensibility Guide
+
+`oidcmw` is designed to adapt to a variety of deployment topologies. The middleware can be extended without forking by wiring the following hooks.
+
+## Token Sources
+
+Tokens are extracted via `tokensource.Source` implementations. Compose built-in sources or provide your own:
+
+```go
+cfg.TokenSources = []tokensource.Source{
+        tokensource.Cookie("session"),
+        tokensource.AuthorizationHeader(),
+        tokensource.HeaderWithScheme("X-Auth", "Bearer"),
+}
+```
+
+Configuration files accept descriptors such as `"cookie:session"` or `"header:X-Auth:Bearer"`. Write custom sources with `tokensource.SourceFunc`.
+
+## Custom Claim Validation
+
+Attach additional claim validation logic through `config.Config.ClaimsValidators`:
+
+```go
+cfg.ClaimsValidators = []config.ClaimsValidator{
+        func(ctx context.Context, claims map[string]any) error {
+                if claims["acr"] != "2" {
+                        return fmt.Errorf("acr level insufficient")
+                }
+                return nil
+        },
+}
+```
+
+Return a `*oidc.ValidationError` to control the HTTP response code precisely.
+
+## Error Responses
+
+Override `config.Config.ErrorResponseBuilder` to customize the error payload returned to callers. The builder receives the RFC 6750 error code and a human-readable description.
+
+## HTTP Clients and MTLS
+
+Inject a custom `http.Client` via `config.Config.HTTPClient` to tune timeouts, TLS settings, or retries. Combine with Go's `http.Transport` to support mutual TLS or proxy routing:
+
+```go
+cfg.HTTPClient = &http.Client{
+        Timeout: 5 * time.Second,
+        Transport: &http.Transport{
+                TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS13},
+        },
+}
+```
+
+## Metrics and Tracing
+
+Supply a metrics recorder and tracer to integrate with your observability stack. The `observability` package exposes a Prometheus-friendly implementation, while any `trace.Tracer` from OpenTelemetry can be used for distributed tracing.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,16 @@
+# Frequently Asked Questions
+
+### Does the middleware refresh JWKS keys automatically?
+Yes. The underlying `go-oidc` verifier caches keys and refreshes them when signatures fail. Configure your own `http.Client` to adjust cache lifetimes or retry behavior.
+
+### Can I validate tokens from multiple issuers?
+The current release focuses on a single issuer. Run multiple middleware instances or construct separate `http.ServeMux` paths when supporting multi-tenant issuers. Multi-issuer routing is on the roadmap.
+
+### How do I enforce scope-based authorization?
+Use the helper predicates on `viewer.Viewer` such as `HasAnyScope`. Combine them with your domain-specific authorization logic inside handlers.
+
+### Is session management supported?
+No. The middleware validates stateless bearer tokens. Integrate with your identity provider's refresh token flow or session management features externally.
+
+### What happens if the issuer is temporarily unreachable?
+Validation fails closed: requests are rejected with `invalid_token`. Configure retries and timeouts on the HTTP client and consider deploying local JWKS caches when network instability is expected.

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -126,36 +126,36 @@ a review walkthrough, updated documentation, and a regression test run (`go test
 ## Detailed TODOs
 
 ### Iteration 1 Checklist
-- [ ] Scaffold middleware, config, and internal OIDC packages with buildable skeletons.
-- [ ] Implement Authorization header token extractor and interface for alternative sources.
-- [ ] Wire OIDC provider client, JWKS cache, and signature verification with configurable timeouts.
-- [ ] Enforce baseline claim validation (`exp`, `iat`, `nbf`, `iss`, `aud`, `azp`) with an opt-in path for token type (`typ`) allow-listing.
-- [ ] Provide structured error responses and redact sensitive claim data.
-- [ ] Author unit tests for happy path, invalid signature, expired token, and JWKS fetch failure.
+- [x] Scaffold middleware, config, and internal OIDC packages with buildable skeletons.
+- [x] Implement Authorization header token extractor and interface for alternative sources.
+- [x] Wire OIDC provider client, JWKS cache, and signature verification with configurable timeouts.
+- [x] Enforce baseline claim validation (`exp`, `iat`, `nbf`, `iss`, `aud`, `azp`) with an opt-in path for token type (`typ`) allow-listing.
+- [x] Provide structured error responses and redact sensitive claim data.
+- [x] Author unit tests for happy path, invalid signature, expired token, and JWKS fetch failure.
 
 ### Iteration 2 Checklist
-- [ ] Define `Viewer` struct and context accessor helpers.
-- [ ] Map standard claims to viewer fields with normalization logic and tests.
-- [ ] Implement realm/resource role parsing preserving unknown roles.
-- [ ] Add scope parsing utilities supporting multiple claim formats.
-- [ ] Expose authorization helper predicates with table-driven tests.
-- [ ] Document viewer usage with example handler snippet.
+- [x] Define `Viewer` struct and context accessor helpers.
+- [x] Map standard claims to viewer fields with normalization logic and tests.
+- [x] Implement realm/resource role parsing preserving unknown roles.
+- [x] Add scope parsing utilities supporting multiple claim formats.
+- [x] Expose authorization helper predicates with table-driven tests.
+- [x] Document viewer usage with example handler snippet.
 
 ### Iteration 3 Checklist
-- [ ] Finalize `Config` struct covering issuer, audiences, token sources, error policy, and hooks.
-- [ ] Build env var and file-based config loaders with precedence rules and validation errors.
-- [ ] Implement cookie, custom header, and query param token sources registered via interface.
-- [ ] Add custom claim validation hook support and sample usage tests.
-- [ ] Harden HTTP client configuration (timeouts, retry policy, mTLS) and document overrides.
-- [ ] Publish extensibility guide and sample configuration files.
+- [x] Finalize `Config` struct covering issuer, audiences, token sources, error policy, and hooks.
+- [x] Build env var and file-based config loaders with precedence rules and validation errors.
+- [x] Implement cookie, custom header, and query param token sources registered via interface.
+- [x] Add custom claim validation hook support and sample usage tests.
+- [x] Harden HTTP client configuration (timeouts, retry policy, mTLS) and document overrides.
+- [x] Publish extensibility guide and sample configuration files.
 
 ### Iteration 4 Checklist
-- [ ] Integrate structured logging abstraction with context awareness.
-- [ ] Emit Prometheus metrics and expose registration helper.
-- [ ] Provide OpenTelemetry tracing hooks with span attribute safeguards.
-- [ ] Create fake issuer, signer utilities, and helper packages for tests.
-- [ ] Author quick-start, troubleshooting, FAQ, and update README index.
-- [ ] Add GitHub Actions workflow running `go test`, `go vet`, and `staticcheck`.
+- [x] Integrate structured logging abstraction with context awareness.
+- [x] Emit Prometheus metrics and expose registration helper.
+- [x] Provide OpenTelemetry tracing hooks with span attribute safeguards.
+- [x] Create fake issuer, signer utilities, and helper packages for tests.
+- [x] Author quick-start, troubleshooting, FAQ, and update README index.
+- [x] Add GitHub Actions workflow running `go test`, `go vet`, and `staticcheck`.
 
 ## Open Questions & Risks
 | Item | Current Understanding | Proposed Resolution |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,93 @@
+# Quick Start
+
+This guide walks through integrating `oidcmw` with a simple `net/http` application.
+
+## Prerequisites
+
+- Go 1.22 or newer.
+- An OpenID Connect provider (Keycloak, Okta, Auth0, etc.).
+- Client credentials issued by the provider with an audience that matches your API.
+
+## Install the Module
+
+```bash
+go get github.com/deicod/oidcmw
+```
+
+## Configure the Middleware
+
+Populate a configuration struct or load one from disk using the helpers in the `config` package. The example below shows configuration driven by YAML with environment variable overrides:
+
+```go
+cfg, err := config.Load(config.LoadOptions{
+        File:      "./config/oidc.yaml",
+        EnvPrefix: "OIDC",
+})
+if err != nil {
+        log.Fatalf("load config: %v", err)
+}
+```
+
+A minimal configuration contains the issuer URL and either audiences or authorized parties:
+
+```yaml
+issuer: https://auth.example.com/realms/demo
+audiences:
+  - account
+authorized_parties:
+  - spa
+```
+
+## Protect Handlers
+
+Wrap your handlers with `middleware.NewMiddleware`. Validated requests include a `viewer.Viewer` in the request context for downstream authorization decisions.
+
+```go
+mw, err := middleware.NewMiddleware(cfg)
+if err != nil {
+        log.Fatalf("middleware setup failed: %v", err)
+}
+
+mux := http.NewServeMux()
+mux.Handle("/protected", mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        v, err := viewer.FromContext(r.Context())
+        if err != nil {
+                http.Error(w, "unauthorized", http.StatusUnauthorized)
+                return
+        }
+        if !v.HasRealmRole("default-roles-demo") {
+                http.Error(w, "forbidden", http.StatusForbidden)
+                return
+        }
+        w.Write([]byte("ok"))
+})))
+```
+
+## Observability Hooks
+
+Provide a Prometheus registerer and OpenTelemetry tracer to collect metrics and traces:
+
+```go
+registry := prometheus.NewRegistry()
+metrics, err := observability.NewMetrics(observability.MetricsOptions{Registerer: registry, Namespace: "oidcmw"})
+if err != nil {
+        log.Fatalf("metrics: %v", err)
+}
+
+cfg.MetricsRecorder = metrics
+cfg.Tracer = otel.GetTracerProvider().Tracer("auth")
+```
+
+Errors are logged with `log/slog` by default. Supply a custom logger through `config.Config.Logger` to integrate with your logging pipeline.
+
+## Verify Locally
+
+Use the `testutil` package to emulate an issuer during development or when writing unit tests. See [Testing Helpers](testing.md) for details.
+
+Run the full validation suite before committing changes:
+
+```bash
+go test ./...
+go vet ./...
+staticcheck ./...
+```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,49 @@
+# Testing Helpers
+
+The `testutil` package ships with utilities for exercising the middleware without relying on an external identity provider.
+
+## Spin Up a Fake Issuer
+
+```go
+issuer := testutil.NewIssuer(t)
+cfg := config.Config{Issuer: issuer.URL(), Audiences: []string{"account"}}
+
+mw, err := middleware.NewMiddleware(cfg)
+require.NoError(t, err)
+```
+
+`NewIssuer` starts an `httptest.Server` that exposes discovery and JWKS endpoints. The server is closed automatically when the test finishes.
+
+## Issue Tokens
+
+Call `issuer.SignToken` to mint RS256-signed JWTs:
+
+```go
+now := time.Now().Add(-time.Minute)
+token := issuer.SignToken(map[string]any{
+        "iss": issuer.URL(),
+        "sub": "subject",
+        "aud": "account",
+        "exp": now.Add(time.Minute).Unix(),
+        "iat": now.Unix(),
+})
+```
+
+For negative tests, use `testutil.SignTokenWithKey` together with `testutil.GenerateRSAKey` to craft tokens signed by alternative keys.
+
+## Customize Keys
+
+`NewIssuer` accepts options that control the generated signing key:
+
+```go
+issuer := testutil.NewIssuer(t,
+        testutil.WithKeyID("kid-1"),
+        testutil.WithKeyBits(3072),
+)
+```
+
+Provide a pre-generated key with `testutil.WithSigningKey` when deterministic key material is required.
+
+## Fetch JWKS
+
+The JWKS endpoint is available at `issuer.URL() + "/jwks"`, making it easy to feed the signing keys into other systems or snapshot them for contract tests.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,28 @@
+# Troubleshooting
+
+Common issues and suggested resolutions when integrating the middleware.
+
+## Invalid Audience
+
+- **Symptom**: Responses contain `{"error":"invalid_token"}` with logs mentioning `audience claim not allowed`.
+- **Fix**: Ensure the configured audiences match the `aud` claim in issued tokens. Wildcards are not supported; list every acceptable audience explicitly.
+
+## JWKS Fetch Failures
+
+- **Symptom**: Validation fails with `token verification failed` and the middleware logs network errors.
+- **Fix**: Verify outbound connectivity to the issuer, check firewall rules, and confirm the issuer's JWKS endpoint is reachable. Override `config.Config.HTTPClient` to add custom transports, proxies, or TLS settings when necessary.
+
+## Token Type Mismatch
+
+- **Symptom**: Requests fail after enabling `TokenTypes` with `token type not allowed`.
+- **Fix**: Inspect the `typ` header of access tokens. Many providers omit this field from the claim set; remove the restriction unless your provider explicitly supplies it.
+
+## Clock Skew Errors
+
+- **Symptom**: Recently issued tokens are rejected with `token used before issued` or `token is not yet valid`.
+- **Fix**: Adjust `config.Config.ClockSkew` to match the maximum difference between the issuer and service clocks. The default tolerance is 30 seconds.
+
+## Missing Viewer in Context
+
+- **Symptom**: Handlers calling `viewer.FromContext` receive `viewer: viewer not found in context`.
+- **Fix**: Confirm the handler is wrapped with the middleware and that no other middleware replaces the request context. If you store the viewer before calling downstream handlers, forward the derived context explicitly.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/deicod/oidcmw
 
-go 1.25.1
+go 1.23.0
+
+toolchain go1.24.3
 
 require (
 	github.com/coreos/go-oidc/v3 v3.15.0

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -2,34 +2,29 @@ package middleware
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
-	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/deicod/oidcmw/config"
+	"github.com/deicod/oidcmw/testutil"
 	"github.com/deicod/oidcmw/tokensource"
 	"github.com/deicod/oidcmw/viewer"
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestMiddleware_AllowsValidToken(t *testing.T) {
-	issuer := newTestIssuer(t)
-	t.Cleanup(issuer.Close)
+	issuer := testutil.NewIssuer(t)
 
 	cfg := config.Config{
-		Issuer:            issuer.issuer,
+		Issuer:            issuer.URL(),
 		Audiences:         []string{"account"},
 		AuthorizedParties: []string{"spa"},
 	}
@@ -55,7 +50,7 @@ func TestMiddleware_AllowsValidToken(t *testing.T) {
 
 	now := time.Now().Add(-1 * time.Minute)
 	claims := map[string]any{
-		"iss":                issuer.issuer,
+		"iss":                issuer.URL(),
 		"sub":                "subject",
 		"aud":                "account",
 		"exp":                now.Add(2 * time.Minute).Unix(),
@@ -76,7 +71,7 @@ func TestMiddleware_AllowsValidToken(t *testing.T) {
 		"scope": "openid email profile",
 	}
 
-	token := issuer.signToken(t, claims)
+	token := issuer.SignToken(claims)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -88,10 +83,9 @@ func TestMiddleware_AllowsValidToken(t *testing.T) {
 }
 
 func TestMiddleware_RejectsInvalidSignature(t *testing.T) {
-	issuer := newTestIssuer(t)
-	t.Cleanup(issuer.Close)
+	issuer := testutil.NewIssuer(t)
 
-	mw, err := NewMiddleware(config.Config{Issuer: issuer.issuer, Audiences: []string{"account"}})
+	mw, err := NewMiddleware(config.Config{Issuer: issuer.URL(), Audiences: []string{"account"}})
 	require.NoError(t, err)
 
 	handler := mw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
@@ -100,7 +94,7 @@ func TestMiddleware_RejectsInvalidSignature(t *testing.T) {
 
 	now := time.Now()
 	claims := map[string]any{
-		"iss": issuer.issuer,
+		"iss": issuer.URL(),
 		"sub": "subject",
 		"aud": "account",
 		"exp": now.Add(time.Minute).Unix(),
@@ -108,7 +102,7 @@ func TestMiddleware_RejectsInvalidSignature(t *testing.T) {
 		"typ": "Bearer",
 	}
 
-	token := signWithDifferentKey(t, claims)
+	token := testutil.SignTokenWithKey(t, testutil.GenerateRSAKey(t, 2048), "other", claims)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -123,10 +117,9 @@ func TestMiddleware_RejectsInvalidSignature(t *testing.T) {
 }
 
 func TestMiddleware_RejectsExpiredToken(t *testing.T) {
-	issuer := newTestIssuer(t)
-	t.Cleanup(issuer.Close)
+	issuer := testutil.NewIssuer(t)
 
-	mw, err := NewMiddleware(config.Config{Issuer: issuer.issuer, Audiences: []string{"account"}})
+	mw, err := NewMiddleware(config.Config{Issuer: issuer.URL(), Audiences: []string{"account"}})
 	require.NoError(t, err)
 
 	handler := mw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
@@ -135,7 +128,7 @@ func TestMiddleware_RejectsExpiredToken(t *testing.T) {
 
 	now := time.Now().Add(-2 * time.Minute)
 	claims := map[string]any{
-		"iss": issuer.issuer,
+		"iss": issuer.URL(),
 		"sub": "subject",
 		"aud": "account",
 		"exp": now.Unix(),
@@ -143,7 +136,7 @@ func TestMiddleware_RejectsExpiredToken(t *testing.T) {
 		"typ": "Bearer",
 	}
 
-	token := issuer.signToken(t, claims)
+	token := issuer.SignToken(claims)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -158,8 +151,8 @@ func TestMiddleware_RejectsExpiredToken(t *testing.T) {
 }
 
 func TestMiddleware_JWKSFetchFailure(t *testing.T) {
-	issuer := newTestIssuer(t)
-	cfg := config.Config{Issuer: issuer.issuer, Audiences: []string{"account"}}
+	issuer := testutil.NewIssuer(t)
+	cfg := config.Config{Issuer: issuer.URL(), Audiences: []string{"account"}}
 	mw, err := NewMiddleware(cfg)
 	require.NoError(t, err)
 
@@ -169,7 +162,7 @@ func TestMiddleware_JWKSFetchFailure(t *testing.T) {
 
 	now := time.Now()
 	claims := map[string]any{
-		"iss": issuer.issuer,
+		"iss": issuer.URL(),
 		"sub": "subject",
 		"aud": "account",
 		"exp": now.Add(time.Minute).Unix(),
@@ -177,7 +170,7 @@ func TestMiddleware_JWKSFetchFailure(t *testing.T) {
 		"typ": "Bearer",
 	}
 
-	token := issuer.signToken(t, claims)
+	token := issuer.SignToken(claims)
 	issuer.Close()
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -193,10 +186,9 @@ func TestMiddleware_JWKSFetchFailure(t *testing.T) {
 }
 
 func TestMiddleware_RejectsMalformedToken(t *testing.T) {
-	issuer := newTestIssuer(t)
-	t.Cleanup(issuer.Close)
+	issuer := testutil.NewIssuer(t)
 
-	mw, err := NewMiddleware(config.Config{Issuer: issuer.issuer})
+	mw, err := NewMiddleware(config.Config{Issuer: issuer.URL()})
 	require.NoError(t, err)
 
 	handler := mw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
@@ -216,10 +208,9 @@ func TestMiddleware_RejectsMalformedToken(t *testing.T) {
 }
 
 func TestMiddleware_RejectsMissingAuthorization(t *testing.T) {
-	issuer := newTestIssuer(t)
-	t.Cleanup(issuer.Close)
+	issuer := testutil.NewIssuer(t)
 
-	mw, err := NewMiddleware(config.Config{Issuer: issuer.issuer})
+	mw, err := NewMiddleware(config.Config{Issuer: issuer.URL()})
 	require.NoError(t, err)
 
 	handler := mw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
@@ -238,11 +229,10 @@ func TestMiddleware_RejectsMissingAuthorization(t *testing.T) {
 }
 
 func TestMiddleware_CustomTokenSources(t *testing.T) {
-	issuer := newTestIssuer(t)
-	t.Cleanup(issuer.Close)
+	issuer := testutil.NewIssuer(t)
 
 	cfg := config.Config{
-		Issuer:    issuer.issuer,
+		Issuer:    issuer.URL(),
 		Audiences: []string{"account"},
 		TokenSources: []tokensource.Source{
 			tokensource.Cookie("session"),
@@ -259,14 +249,14 @@ func TestMiddleware_CustomTokenSources(t *testing.T) {
 
 	now := time.Now()
 	claims := map[string]any{
-		"iss": issuer.issuer,
+		"iss": issuer.URL(),
 		"sub": "subject",
 		"aud": "account",
 		"exp": now.Add(time.Minute).Unix(),
 		"iat": now.Add(-time.Minute).Unix(),
 	}
 
-	token := issuer.signToken(t, claims)
+	token := issuer.SignToken(claims)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.AddCookie(&http.Cookie{Name: "session", Value: token})
@@ -279,12 +269,11 @@ func TestMiddleware_CustomTokenSources(t *testing.T) {
 }
 
 func TestMiddleware_CustomClaimsValidator(t *testing.T) {
-	issuer := newTestIssuer(t)
-	t.Cleanup(issuer.Close)
+	issuer := testutil.NewIssuer(t)
 
 	var invoked bool
 	cfg := config.Config{
-		Issuer:    issuer.issuer,
+		Issuer:    issuer.URL(),
 		Audiences: []string{"account"},
 		ClaimsValidators: []config.ClaimsValidator{
 			func(ctx context.Context, claims map[string]any) error {
@@ -306,7 +295,7 @@ func TestMiddleware_CustomClaimsValidator(t *testing.T) {
 
 	now := time.Now()
 	claims := map[string]any{
-		"iss":                issuer.issuer,
+		"iss":                issuer.URL(),
 		"sub":                "subject",
 		"aud":                "account",
 		"exp":                now.Add(time.Minute).Unix(),
@@ -314,7 +303,7 @@ func TestMiddleware_CustomClaimsValidator(t *testing.T) {
 		"preferred_username": "alice",
 	}
 
-	token := issuer.signToken(t, claims)
+	token := issuer.SignToken(claims)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -327,11 +316,10 @@ func TestMiddleware_CustomClaimsValidator(t *testing.T) {
 }
 
 func TestMiddleware_CustomClaimsValidatorRejects(t *testing.T) {
-	issuer := newTestIssuer(t)
-	t.Cleanup(issuer.Close)
+	issuer := testutil.NewIssuer(t)
 
 	cfg := config.Config{
-		Issuer:    issuer.issuer,
+		Issuer:    issuer.URL(),
 		Audiences: []string{"account"},
 		ClaimsValidators: []config.ClaimsValidator{
 			func(ctx context.Context, claims map[string]any) error {
@@ -349,14 +337,14 @@ func TestMiddleware_CustomClaimsValidatorRejects(t *testing.T) {
 
 	now := time.Now()
 	claims := map[string]any{
-		"iss": issuer.issuer,
+		"iss": issuer.URL(),
 		"sub": "subject",
 		"aud": "account",
 		"exp": now.Add(time.Minute).Unix(),
 		"iat": now.Add(-time.Minute).Unix(),
 	}
 
-	token := issuer.signToken(t, claims)
+	token := issuer.SignToken(claims)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -371,8 +359,7 @@ func TestMiddleware_CustomClaimsValidatorRejects(t *testing.T) {
 }
 
 func TestMiddleware_RecordsMetricsOnSuccess(t *testing.T) {
-	issuer := newTestIssuer(t)
-	t.Cleanup(issuer.Close)
+	issuer := testutil.NewIssuer(t)
 
 	recorder := &capturingMetrics{}
 	spanRecorder := tracetest.NewSpanRecorder()
@@ -381,7 +368,7 @@ func TestMiddleware_RecordsMetricsOnSuccess(t *testing.T) {
 		_ = tracerProvider.Shutdown(context.Background())
 	})
 	cfg := config.Config{
-		Issuer:          issuer.issuer,
+		Issuer:          issuer.URL(),
 		Audiences:       []string{"account"},
 		MetricsRecorder: recorder,
 		Tracer:          tracerProvider.Tracer("middleware-test"),
@@ -397,14 +384,14 @@ func TestMiddleware_RecordsMetricsOnSuccess(t *testing.T) {
 
 	now := time.Now()
 	claims := map[string]any{
-		"iss": issuer.issuer,
+		"iss": issuer.URL(),
 		"sub": "subject",
 		"aud": "account",
 		"exp": now.Add(time.Minute).Unix(),
 		"iat": now.Add(-time.Minute).Unix(),
 	}
 
-	token := issuer.signToken(t, claims)
+	token := issuer.SignToken(claims)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -422,8 +409,7 @@ func TestMiddleware_RecordsMetricsOnSuccess(t *testing.T) {
 }
 
 func TestMiddleware_RecordsMetricsOnFailure(t *testing.T) {
-	issuer := newTestIssuer(t)
-	t.Cleanup(issuer.Close)
+	issuer := testutil.NewIssuer(t)
 
 	recorder := &capturingMetrics{}
 	spanRecorder := tracetest.NewSpanRecorder()
@@ -432,7 +418,7 @@ func TestMiddleware_RecordsMetricsOnFailure(t *testing.T) {
 		_ = tracerProvider.Shutdown(context.Background())
 	})
 	cfg := config.Config{
-		Issuer:          issuer.issuer,
+		Issuer:          issuer.URL(),
 		MetricsRecorder: recorder,
 		Tracer:          tracerProvider.Tracer("middleware-test"),
 		Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -459,94 +445,10 @@ func TestMiddleware_RecordsMetricsOnFailure(t *testing.T) {
 	require.Len(t, spans, 1)
 }
 
-type testIssuer struct {
-	server *httptest.Server
-	issuer string
-	key    *rsa.PrivateKey
-	keyID  string
-	jwks   []byte
-}
-
 type capturingMetrics struct {
 	events []config.MetricsEvent
 }
 
 func (c *capturingMetrics) RecordValidation(_ context.Context, event config.MetricsEvent) {
 	c.events = append(c.events, event)
-}
-
-func newTestIssuer(t *testing.T) *testIssuer {
-	t.Helper()
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-
-	ti := &testIssuer{key: key, keyID: "test-key"}
-	ti.jwks = buildJWKS(t, key, ti.keyID)
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		response := map[string]any{
-			"issuer":                 ti.issuer,
-			"jwks_uri":               ti.issuer + "/jwks",
-			"token_endpoint":         ti.issuer + "/token",
-			"authorization_endpoint": ti.issuer + "/auth",
-		}
-		_ = json.NewEncoder(w).Encode(response)
-	})
-	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(ti.jwks)
-	})
-
-	server := httptest.NewServer(mux)
-	ti.server = server
-	ti.issuer = server.URL
-
-	return ti
-}
-
-func (ti *testIssuer) signToken(t *testing.T, claims map[string]any) string {
-	t.Helper()
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(claims))
-	token.Header["kid"] = ti.keyID
-	signed, err := token.SignedString(ti.key)
-	require.NoError(t, err)
-	return signed
-}
-
-func (ti *testIssuer) Close() {
-	if ti.server != nil {
-		ti.server.Close()
-	}
-}
-
-func buildJWKS(t *testing.T, key *rsa.PrivateKey, keyID string) []byte {
-	t.Helper()
-	n := base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes())
-	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes())
-
-	jwk := map[string]any{
-		"kty": "RSA",
-		"alg": "RS256",
-		"use": "sig",
-		"kid": keyID,
-		"n":   n,
-		"e":   e,
-	}
-
-	body, err := json.Marshal(map[string]any{"keys": []any{jwk}})
-	require.NoError(t, err)
-	return body
-}
-
-func signWithDifferentKey(t *testing.T, claims map[string]any) string {
-	t.Helper()
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(claims))
-	token.Header["kid"] = "other"
-	signed, err := token.SignedString(key)
-	require.NoError(t, err)
-	return signed
 }

--- a/testutil/issuer.go
+++ b/testutil/issuer.go
@@ -1,0 +1,198 @@
+package testutil
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// Issuer represents an in-memory OpenID Connect provider suitable for tests.
+type Issuer struct {
+	tb     testing.TB
+	server *httptest.Server
+	key    *rsa.PrivateKey
+	keyID  string
+	jwks   []byte
+}
+
+// IssuerOption configures Issuer construction.
+type IssuerOption func(*issuerConfig)
+
+type issuerConfig struct {
+	Key     *rsa.PrivateKey
+	KeyID   string
+	KeyBits int
+}
+
+// WithSigningKey supplies a pre-generated RSA private key for the issuer.
+func WithSigningKey(key *rsa.PrivateKey) IssuerOption {
+	return func(cfg *issuerConfig) {
+		cfg.Key = key
+	}
+}
+
+// WithKeyID overrides the key identifier exposed in the JWKS document.
+func WithKeyID(keyID string) IssuerOption {
+	return func(cfg *issuerConfig) {
+		cfg.KeyID = keyID
+	}
+}
+
+// WithKeyBits customizes the RSA key size when a key is generated automatically.
+func WithKeyBits(bits int) IssuerOption {
+	return func(cfg *issuerConfig) {
+		cfg.KeyBits = bits
+	}
+}
+
+// NewIssuer spins up an HTTP server that mimics an OpenID Connect provider for tests.
+// The returned Issuer automatically registers a cleanup handler on tb.
+func NewIssuer(tb testing.TB, opts ...IssuerOption) *Issuer {
+	tb.Helper()
+
+	cfg := issuerConfig{
+		KeyBits: 2048,
+		KeyID:   "test-key",
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	key := cfg.Key
+	if key == nil {
+		var err error
+		key, err = rsa.GenerateKey(rand.Reader, cfg.KeyBits)
+		if err != nil {
+			tb.Fatalf("testutil: generate RSA key: %v", err)
+		}
+	}
+
+	iss := &Issuer{tb: tb, key: key, keyID: cfg.KeyID}
+	jwks, err := buildJWKS(key, cfg.KeyID)
+	if err != nil {
+		tb.Fatalf("testutil: build JWKS: %v", err)
+	}
+	iss.jwks = jwks
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		response := map[string]any{
+			"issuer":                 iss.URL(),
+			"jwks_uri":               iss.URL() + "/jwks",
+			"token_endpoint":         iss.URL() + "/token",
+			"authorization_endpoint": iss.URL() + "/auth",
+		}
+		_ = json.NewEncoder(w).Encode(response)
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(iss.jwks)
+	})
+
+	server := httptest.NewServer(mux)
+	iss.server = server
+	tb.Cleanup(iss.Close)
+
+	return iss
+}
+
+// URL returns the issuer base URL.
+func (i *Issuer) URL() string {
+	if i == nil || i.server == nil {
+		return ""
+	}
+	return i.server.URL
+}
+
+// SignToken signs the provided claims and returns a compact JWT string.
+func (i *Issuer) SignToken(claims map[string]any) string {
+	i.tb.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(claims))
+	if i.keyID != "" {
+		token.Header["kid"] = i.keyID
+	}
+	signed, err := token.SignedString(i.key)
+	if err != nil {
+		i.tb.Fatalf("testutil: sign token: %v", err)
+	}
+	return signed
+}
+
+// Close shuts down the underlying HTTP server.
+func (i *Issuer) Close() {
+	if i == nil || i.server == nil {
+		return
+	}
+	i.server.Close()
+	i.server = nil
+}
+
+// SigningKey returns the issuer's RSA private key.
+func (i *Issuer) SigningKey() *rsa.PrivateKey {
+	if i == nil {
+		return nil
+	}
+	return i.key
+}
+
+// KeyID returns the identifier attached to the signing key.
+func (i *Issuer) KeyID() string {
+	if i == nil {
+		return ""
+	}
+	return i.keyID
+}
+
+// GenerateRSAKey creates an RSA private key with the provided size.
+func GenerateRSAKey(tb testing.TB, bits int) *rsa.PrivateKey {
+	tb.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		tb.Fatalf("testutil: generate RSA key: %v", err)
+	}
+	return key
+}
+
+// SignTokenWithKey signs the claims using the provided key and key identifier.
+func SignTokenWithKey(tb testing.TB, key *rsa.PrivateKey, keyID string, claims map[string]any) string {
+	tb.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(claims))
+	if keyID != "" {
+		token.Header["kid"] = keyID
+	}
+	signed, err := token.SignedString(key)
+	if err != nil {
+		tb.Fatalf("testutil: sign token with key: %v", err)
+	}
+	return signed
+}
+
+func buildJWKS(key *rsa.PrivateKey, keyID string) ([]byte, error) {
+	if key == nil {
+		return nil, errors.New("testutil: RSA key is nil")
+	}
+	modulus := base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes())
+	exponent := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes())
+	jwk := map[string]any{
+		"kty": "RSA",
+		"alg": "RS256",
+		"use": "sig",
+		"kid": keyID,
+		"n":   modulus,
+		"e":   exponent,
+	}
+	body, err := json.Marshal(map[string]any{"keys": []any{jwk}})
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}

--- a/testutil/issuer_test.go
+++ b/testutil/issuer_test.go
@@ -1,0 +1,58 @@
+package testutil
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/deicod/oidcmw/config"
+	internaloidc "github.com/deicod/oidcmw/internal/oidc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssuer_SignTokenValidates(t *testing.T) {
+	issuer := NewIssuer(t)
+
+	cfg := config.Config{
+		Issuer:            issuer.URL(),
+		Audiences:         []string{"account"},
+		AuthorizedParties: []string{"spa"},
+	}
+
+	validator, err := internaloidc.NewValidator(context.Background(), cfg)
+	require.NoError(t, err)
+
+	now := time.Now().Add(-time.Minute)
+	claims := map[string]any{
+		"iss": issuer.URL(),
+		"sub": "subject",
+		"aud": "account",
+		"exp": now.Add(2 * time.Minute).Unix(),
+		"iat": now.Unix(),
+		"azp": "spa",
+	}
+
+	token := issuer.SignToken(claims)
+
+	_, err = validator.Validate(context.Background(), token)
+	require.NoError(t, err)
+}
+
+func TestIssuer_ExposesJWKS(t *testing.T) {
+	issuer := NewIssuer(t)
+
+	resp, err := http.Get(issuer.URL() + "/jwks")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestSignTokenWithKey_UsesCustomKey(t *testing.T) {
+	key := GenerateRSAKey(t, 2048)
+
+	claims := map[string]any{"sub": "subject"}
+	token := SignTokenWithKey(t, key, "custom", claims)
+	require.NotEmpty(t, token)
+}


### PR DESCRIPTION
## Summary
- add a reusable `testutil` package that hosts a fake OIDC issuer, accompanying tests, and migrate middleware tests to the helper
- document usage with new quick start, extensibility, troubleshooting, FAQ, and testing guides while updating the implementation plan and README index
- introduce a CI workflow that runs formatting, vetting, testing, and static analysis and note the toolchain requirement in go.mod

## Testing
- `go test ./...`
- `go vet ./...`
- `/root/go/bin/staticcheck ./...`


------
https://chatgpt.com/codex/tasks/task_b_68d17b2df278832ebf06665f179ac5cd