### PR TITLE
Ensure validator uses configured HTTP client

### DIFF
--- a/internal/oidc/validator.go
+++ b/internal/oidc/validator.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -37,12 +36,11 @@ type ValidatedToken struct {
 
 // NewValidator constructs a Validator using the provided configuration.
 func NewValidator(ctx context.Context, cfg config.Config) (*Validator, error) {
-	client := cfg.HTTPClient
-	if client == nil {
-		client = http.DefaultClient
+	if cfg.HTTPClient == nil {
+		return nil, fmt.Errorf("oidc: http client is not configured")
 	}
 
-	ctx = oidc.ClientContext(ctx, client)
+	ctx = oidc.ClientContext(ctx, cfg.HTTPClient)
 	provider, err := oidc.NewProvider(ctx, cfg.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("oidc: create provider: %w", err)

--- a/internal/oidc/validator_client_test.go
+++ b/internal/oidc/validator_client_test.go
@@ -1,0 +1,82 @@
+package oidc
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/deicod/oidcmw/config"
+)
+
+func TestNewValidatorUsesConfiguredHTTPClient(t *testing.T) {
+	issuer := "https://issuer.invalid"
+	transport := &stubTransport{t: t}
+	client := &http.Client{Transport: transport}
+
+	cfg := config.Config{
+		Issuer:     issuer,
+		HTTPClient: client,
+	}
+	cfg.SetDefaults()
+
+	if _, err := NewValidator(context.Background(), cfg); err != nil {
+		t.Fatalf("NewValidator returned error: %v", err)
+	}
+
+	if !transport.sawPath("/.well-known/openid-configuration") {
+		t.Fatalf("expected discovery request to use configured client; got paths: %v", transport.paths())
+	}
+}
+
+type stubTransport struct {
+	t    *testing.T
+	mu   sync.Mutex
+	seen []string
+}
+
+func (s *stubTransport) sawPath(path string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, p := range s.seen {
+		if p == path {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *stubTransport) paths() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.seen))
+	copy(out, s.seen)
+	return out
+}
+
+func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.mu.Lock()
+	s.seen = append(s.seen, req.URL.Path)
+	s.mu.Unlock()
+
+	switch req.URL.Path {
+	case "/.well-known/openid-configuration":
+		body := `{"issuer":"` + req.URL.Scheme + "://" + req.URL.Host + `","jwks_uri":"` + req.URL.Scheme + "://" + req.URL.Host + `/keys"}`
+		return s.response(body), nil
+	case "/keys":
+		return s.response(`{"keys":[]}`), nil
+	default:
+		s.t.Fatalf("unexpected request path: %s", req.URL.String())
+		return nil, nil
+	}
+}
+
+func (s *stubTransport) response(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}


### PR DESCRIPTION
## Summary
- configure a default HTTP client with explicit timeouts when none is provided
- ensure the validator requires the configured client instead of falling back to http.DefaultClient
- add a test that verifies the validator uses the supplied client during discovery

## Testing
- go test ./...
- go vet ./...


------
https://chatgpt.com/codex/tasks/task_b_68d1be12b9a8832eae649dffdbe6726f