### PR TITLE
🛡️ Sentinel: [MEDIUM] Add warning and deprecation for URL Query token source

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** The middleware did not explicitly check for the presence of the `sub` (subject) claim in ID Tokens.
 **Learning:** While `go-oidc` verifies signatures, some specific application-level claims like `sub` (which uniquely identifies the principal) need explicit validation if not natively enforced by the verifier configuration or when overriding library defaults. Missing this could lead to empty subjects or misattribution.
 **Prevention:** Always ensure mandatory claims like `sub` are present and non-empty during token validation to prevent identity spoofing or nil principal scenarios downstream.
+## 2026-03-07 - Insecure Token Source (Query Parameters)
+**Vulnerability:** The `tokensource.Query` token source extracts bearer tokens from URL query parameters, which are susceptible to exposure through server logs, proxy logs, and browser history/referers.
+**Learning:** While query parameters might seem convenient for token passing, their widespread logging makes them unsuitable for highly sensitive credentials. Removing the capability entirely is an unauthorized breaking API change, so an explicit, logged security warning and code deprecation is the next best mitigation.
+**Prevention:** Always default to Authorization headers or secure, HttpOnly cookies for bearer tokens. Deprecate and warn loudly if query parameter extraction must be maintained for backward compatibility.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,6 +11,6 @@
 **Learning:** While `go-oidc` verifies signatures, some specific application-level claims like `sub` (which uniquely identifies the principal) need explicit validation if not natively enforced by the verifier configuration or when overriding library defaults. Missing this could lead to empty subjects or misattribution.
 **Prevention:** Always ensure mandatory claims like `sub` are present and non-empty during token validation to prevent identity spoofing or nil principal scenarios downstream.
 ## 2026-03-07 - Insecure Token Source (Query Parameters)
-**Vulnerability:** The `tokensource.Query` token source extracts bearer tokens from URL query parameters, which are susceptible to exposure through server logs, proxy logs, and browser history/referers.
+**Vulnerability:** The `tokensource.Query` token source extracts bearer tokens from URL query parameters, which are susceptible to exposure through server logs, proxy logs, and browser history/referrers.
 **Learning:** While query parameters might seem convenient for token passing, their widespread logging makes them unsuitable for highly sensitive credentials. Removing the capability entirely is an unauthorized breaking API change, so an explicit, logged security warning and code deprecation is the next best mitigation.
 **Prevention:** Always default to Authorization headers or secure, HttpOnly cookies for bearer tokens. Deprecate and warn loudly if query parameter extraction must be maintained for backward compatibility.

--- a/internal/oidc/clock_skew_test.go
+++ b/internal/oidc/clock_skew_test.go
@@ -20,10 +20,10 @@ func TestClockSkewRespectsExpiry(t *testing.T) {
 
 	// Config with ClockSkew
 	cfg := config.Config{
-		Issuer:    fi.Issuer(),
-		ClockSkew: time.Minute,
+		Issuer:     fi.Issuer(),
+		ClockSkew:  time.Minute,
 		HTTPClient: http.DefaultClient,
-		Audiences: []string{"test-aud"},
+		Audiences:  []string{"test-aud"},
 		Now: func() time.Time {
 			return now
 		},

--- a/tokensource/token_source.go
+++ b/tokensource/token_source.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 )
 
 // ErrNotFound indicates that a token could not be located by a Source.
@@ -193,16 +194,19 @@ func Cookie(name string) Source {
 //
 // Deprecated: Extracting bearer tokens from query parameters is insecure and may lead to token leakage.
 func Query(name string) Source {
+	var warnOnce sync.Once
 	return SourceFunc(func(r *http.Request) (string, error) {
 		if r.URL == nil {
 			return "", ErrNotFound
 		}
-		value := r.URL.Query().Get(name)
-		if strings.TrimSpace(value) == "" {
+		trimmed := strings.TrimSpace(r.URL.Query().Get(name))
+		if trimmed == "" {
 			return "", ErrNotFound
 		}
-		slog.Warn("security warning: extracting bearer token from query parameter is insecure and may lead to token leakage")
-		return strings.TrimSpace(value), nil
+		warnOnce.Do(func() {
+			slog.WarnContext(r.Context(), "security warning: extracting bearer token from query parameter is insecure and may lead to token leakage", slog.String("param", name))
+		})
+		return trimmed, nil
 	})
 }
 

--- a/tokensource/token_source.go
+++ b/tokensource/token_source.go
@@ -3,6 +3,7 @@ package tokensource
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -35,6 +36,8 @@ const (
 	// TypeCookie reads tokens from an HTTP cookie.
 	TypeCookie Type = "cookie"
 	// TypeQuery reads tokens from a query string parameter.
+	//
+	// Deprecated: Extracting bearer tokens from query parameters is insecure and may lead to token leakage.
 	TypeQuery Type = "query"
 	// TypeWebSocketProtocol reads tokens from the Sec-WebSocket-Protocol header.
 	TypeWebSocketProtocol Type = "websocket_protocol"
@@ -187,6 +190,8 @@ func Cookie(name string) Source {
 }
 
 // Query extracts tokens from a query string parameter.
+//
+// Deprecated: Extracting bearer tokens from query parameters is insecure and may lead to token leakage.
 func Query(name string) Source {
 	return SourceFunc(func(r *http.Request) (string, error) {
 		if r.URL == nil {
@@ -196,6 +201,7 @@ func Query(name string) Source {
 		if strings.TrimSpace(value) == "" {
 			return "", ErrNotFound
 		}
+		slog.Warn("security warning: extracting bearer token from query parameter is insecure and may lead to token leakage")
 		return strings.TrimSpace(value), nil
 	})
 }

--- a/tokensource/token_source_test.go
+++ b/tokensource/token_source_test.go
@@ -1,9 +1,12 @@
 package tokensource
 
 import (
+	"bytes"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -170,11 +173,29 @@ func TestCookie(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/?access=abc", nil)
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
 
-	token, err := Query("access").Extract(req)
-	require.NoError(t, err)
-	require.Equal(t, "abc", token)
+	oldLogger := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(oldLogger) })
+	slog.SetDefault(logger)
+
+	source := Query("access")
+
+	req1 := httptest.NewRequest(http.MethodGet, "/?access=abc", nil)
+	token1, err1 := source.Extract(req1)
+	require.NoError(t, err1)
+	require.Equal(t, "abc", token1)
+
+	req2 := httptest.NewRequest(http.MethodGet, "/?access=def", nil)
+	token2, err2 := source.Extract(req2)
+	require.NoError(t, err2)
+	require.Equal(t, "def", token2)
+
+	logOutput := buf.String()
+	require.Contains(t, logOutput, "security warning: extracting bearer token from query parameter is insecure")
+	// The warning should only be logged once because of sync.Once
+	require.Equal(t, 1, strings.Count(logOutput, "security warning"))
 }
 
 func TestDefinitionBuild(t *testing.T) {


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add warning and deprecation for URL Query token source

🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The `tokensource.Query` token source extracts bearer tokens from URL query parameters. Passing credentials in URLs is a known security vulnerability (CWE-598) because URLs are frequently logged in web server access logs, proxy logs, and exposed to external domains via `Referer` headers.
🎯 **Impact**: Attackers gaining access to server logs or intercepting Referer headers could extract valid bearer tokens and impersonate users, leading to unauthorized access.
🔧 **Fix**: Deprecated the `TypeQuery` constant and `tokensource.Query` function. Added a runtime `slog.Warn` security warning that triggers whenever a token is successfully extracted from a query parameter. This alerts administrators to the insecure practice without making breaking API changes. Documented the learning in `.jules/sentinel.md`.
✅ **Verification**:
1. Run `go test ./...` and `go vet ./...` to ensure all tests pass.
2. Verified that the `log/slog` warning is emitted when utilizing the query parameter token source.

---
*PR created automatically by Jules for task [6902741893035061000](https://jules.google.com/task/6902741893035061000) started by @dlukt*