### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix sensitive data leakage in error logging

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -197,10 +197,10 @@ func logFailure(ctx context.Context, logger *slog.Logger, authErr authError) {
 	if logger == nil {
 		return
 	}
+	// Avoid logging authErr.cause directly as it may contain sensitive information like raw tokens
 	logger.WarnContext(ctx, "authentication failed",
 		slog.String("error_code", string(authErr.code)),
 		slog.String("description", authErr.description),
-		slog.Any("cause", authErr.cause),
 	)
 }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Raw error causes (which may include raw bearer tokens or structured sensitive claim data) were directly dumped to the logger using `slog.Any()`.
🎯 Impact: Sensitive user data (PII) or secrets like bearer tokens could be inadvertently leaked into central logging systems where more employees or external systems have access.
🔧 Fix: Removed `slog.Any("cause", authErr.cause)` from the log call in `logFailure` within `middleware/middleware.go`.
✅ Verification: Review `logFailure` to ensure the cause field is no longer included. Run `go test ./...` and `go vet ./...` to verify functionality.

---
*PR created automatically by Jules for task [18062233608206642679](https://jules.google.com/task/18062233608206642679) started by @dlukt*